### PR TITLE
Harmonize createToken across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+Changelog
+==============================
+
+## 3.0.0 (2017, August 1)
+### Breaking Changes
+- [(# 6)](https://github.com/triniwiz/nativescript-stripe/issues/6) Android `createToken` now send back the full token object instead of only the `tokenId`
+
+## 1.0.1 (2017, May 7)
+### Breaking Changes
+- Nativescript 3 compatibility
+### Fixes
+- [(# 3)](https://github.com/triniwiz/nativescript-stripe/issues/3) validate expiration month with value `1`
+
+## 1.0.1 (2017, March 27)
+### Fixes
+- [(# 1)](https://github.com/triniwiz/nativescript-stripe/issues/1) Fixed new Card creation via code
+
+## 1.0.0 (2017, March 19)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ stripe.createToken(cc.card,(error,token)=>{
   }
 });
 ```
+**Warning** At the moment the `token` sent back by createToken doesn't have the same API depending on the platform.
+
+For exemple, iOS will send back an object having `tokenId` or `card` properties while the Android version will have accessors like `getId()` or `getCard()`.
 
 
 # TODO

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-stripe",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "",
   "main": "stripe",
   "nativescript": {

--- a/src/android/stripe.ts
+++ b/src/android/stripe.ts
@@ -15,7 +15,7 @@ export class Stripe {
                 owner: that.get(),
                 onSuccess: function (token) {
                     if (typeof cb === "function") {
-                        cb(null, token.getId());
+                        cb(null, token);
                     }
                 },
                 onError: function (error) {


### PR DESCRIPTION
As stated in issue #6, `createToken` method send back only the `tokenId` on Android. This PR change the method so it sends back the full object.
Also, this PR contains:
- A major version bump (`2.0.2` -> `3.0.0`) as the API change.
- Add a warning on the `README` regarding the `createToken` return API differences between platforms.
- Add a `CHANGELOG` file.

Thos are just what I thought was needed but it's up to discussion and your call ultimately 😄 .
Let me know if you see anything you think could be improved or you want to be done differently!