### PR TITLE
Updating Stripe SDK on Android platforms

### DIFF
--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -7,5 +7,5 @@ android {
 }
 
 dependencies {
-    compile 'com.stripe:stripe-android:3.0.1'
+    compile 'com.stripe:stripe-android:8.0.0'
 }

--- a/src/android/card.d.ts
+++ b/src/android/card.d.ts
@@ -1,6 +1,6 @@
 export declare class Card {
     private _card;
-    constructor(cardNumber: string, cardExpMonth: any, cardExpYear: any, cardCVC: string);
+    constructor(cardNumber: string, cardExpMonth: number, cardExpYear: number, cardCVC: string);
     readonly card: any;
     validateNumber(): boolean;
     validateCVC(): boolean;
@@ -9,8 +9,8 @@ export declare class Card {
     validateExpYear(): boolean;
     readonly number: string;
     readonly cvc: string;
-    readonly expMonth: any;
-    readonly expYear: any;
+    readonly expMonth: number;
+    readonly expYear: number;
     name: string;
     addressLine1: string;
     addressLine2: string;

--- a/src/android/card.ts
+++ b/src/android/card.ts
@@ -1,7 +1,7 @@
 declare const com, java;
 export class Card {
     private _card: any /*com.stripe.android.model.Card*/;
-    constructor(cardNumber: string, cardExpMonth: any, cardExpYear: any, cardCVC: string) {
+    constructor(cardNumber: string, cardExpMonth: number, cardExpYear: number, cardCVC: string) {
         this._card = new com.stripe.android.model.Card(
             new java.lang.String(cardNumber),
             new java.lang.Integer(cardExpMonth),
@@ -33,10 +33,10 @@ export class Card {
     get cvc(): string {
         return this._card.getCVC();
     }
-    get expMonth(): any {
+    get expMonth(): number {
         return this._card.getExpMonth();
     }
-    get expYear(): any {
+    get expYear(): number {
         return this._card.getExpYear();
     }
     get name(): string {


### PR DESCRIPTION
This update will bring Android apps to the latest Stripe SDK

- Some fields were set as `any` and would break the expiry date in the latest version of NativeScript
- getters were also updated