### PR TITLE
feat(demo-angular-custom): add support for Custom Integration to demo-angular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 ==============================
 
-## 4.2.0 (2018, October 20)
+## 5.0.0 (2018, October 17)
 ### Additions
 - [(# 24)](https://github.com/triniwiz/nativescript-stripe/issues/24) Add Support for Custom Integration to Angular demo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 ==============================
 
+## 4.2.0 (2018, October 1)
+### Additions
+- [(# 24)](https://github.com/triniwiz/nativescript-stripe/issues/24) Add Support for Custom Integration to Angular demo
+
+### Breaking Changes
+- Now follows recommended approach for registering CreditCardView in Angular
+- `createToken()` now takes `card: CardCommon` as first parameter instead of `card.card: any`.
+
 ## 4.1.1 (2018, October 1)
 ### Additions
 - [(# 23)](https://github.com/triniwiz/nativescript-stripe/issues/23) Add an Angular demo app that demonstrates the Standard integration

--- a/README.md
+++ b/README.md
@@ -23,56 +23,32 @@
 
 * [Android](#android)
 * [iOS](#ios)
+* [Angular](#angular)
 
 ## Android
 
-## IOS
-Place the following in your app.js before `app.start`
-JavaScript
-```js
-var app = require('application');
-var platform = ('platform');
-app.on(app.launchEvent, (args) => {
-    if (platform.isIOS) {
-        STPPaymentConfiguration.sharedConfiguration().publishableKey = "yourApiKey";
-    }
-});
-```
-Place the following in your app.ts before `app.start`
+## iOS
 
-TypeScript
-```ts
-import * as app from 'application';
-import * as platform from 'platform';
-declare const STPPaymentConfiguration;
-app.on(app.launchEvent, (args) => {
-    if (platform.isIOS) {
-        STPPaymentConfiguration.sharedConfiguration().publishableKey = "yourApiKey";
-    }
-});
-```
-
-### Angular
-To use the Custom Integration's CreditCardView, place the following in your main.ts
+## Angular
+To use the Custom Integration's CreditCardView in Angular,
+register the Angular wrapper in the main module (typically `app.module.ts`), as follows:
 
 ```ts
-import { registerElement } from "nativescript-angular/element-registry";
-registerElement("CreditCardView", () => require("nativescript-stripe").CreditCardView);
+...
+import { CreditCardViewModule } from "nativescript-stripe/angular";
+...
+@NgModule({
+  imports: [
+    ...
+    CreditCardViewModule,
+    ...
+  ],
+  ...
+})
+export class AppModule { }
 ```
 
-```ts
-import * as app from 'application';
-import * as platform from "platform";
-declare const STPPaymentConfiguration;
-app.on(app.launchEvent, (args) => {
-    if (platform.isIOS) {
-        STPPaymentConfiguration.sharedConfiguration().publishableKey = "yourApiKey";
-    }
-});
-```
-
-
-## Usage
+# Usage
 
 IMPORTANT: Make sure you include `xmlns:stripe="nativescript-stripe"` on the Page tag
 
@@ -83,12 +59,14 @@ IMPORTANT: Make sure you include `xmlns:stripe="nativescript-stripe"` on the Pag
 
 #### Add extra details to card
 
+JavaScript
 ```js
 const ccView = page.getViewById("card");
 const cc = ccView.card;
 cc.name = "Osei Fortune";
 ```
 
+TypeScript
 ```ts
 import { CreditCardView, Card } from 'nativescript-stripe';
 const ccView:CreditCardView = page.getViewById("card");
@@ -104,10 +82,11 @@ cc.name = "Osei Fortune";
 
 ### Get Token
 
+TypeScript
 ```ts
 import {Stripe} from 'nativescript-stripe';
 const stripe = new Stripe('yourApiKey');
-stripe.createToken(cc.card,(error,token)=>{
+stripe.createToken(cc, (error,token)=>{
   if(!error){
     //Do something with your token;
 
@@ -117,10 +96,11 @@ stripe.createToken(cc.card,(error,token)=>{
 });
 ```
 
+JavaScript
 ```js
-var Stripe =require('nativescript-stripe').Stripe;
+var Stripe = require('nativescript-stripe').Stripe;
 const stripe = new Stripe('yourApiKey');
-stripe.createToken(cc.card,(error,token)=>{
+stripe.createToken(cc, (error,token)=>{
   if(!error){
     //Do something with your token;
 
@@ -130,7 +110,7 @@ stripe.createToken(cc.card,(error,token)=>{
 });
 ```
 
-### Standard Integration
+## Standard Integration
 
 The `demo-angular` folder contains an Angular demo that uses the Standard Integration.
 It can be used as a starting point, and provides information on how to invoke the

--- a/demo-angular/app/app.module.ts
+++ b/demo-angular/app/app.module.ts
@@ -1,7 +1,9 @@
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { CreditCardViewModule } from "nativescript-stripe/angular";
 import { AppComponent } from "./app.component";
 import { AppRoutingModule } from "./app.routing";
+import { CreditCardViewComponent } from "./demo/creditcardview.component";
 import { HomeComponent } from "./demo/home.component";
 import { StandardComponent } from "./demo/standard.component";
 import { StripeService } from "./demo/stripe.service";
@@ -18,12 +20,14 @@ import { StripeService } from "./demo/stripe.service";
   ],
   imports: [
     NativeScriptModule,
-    AppRoutingModule
+    AppRoutingModule,
+    CreditCardViewModule
   ],
   declarations: [
     AppComponent,
     HomeComponent,
-    StandardComponent
+    StandardComponent,
+    CreditCardViewComponent
   ],
   providers: [
     StripeService

--- a/demo-angular/app/app.routing.ts
+++ b/demo-angular/app/app.routing.ts
@@ -1,6 +1,7 @@
 import { NgModule } from "@angular/core";
 import { Routes } from "@angular/router";
 import { NativeScriptRouterModule } from "nativescript-angular/router";
+import { CreditCardViewComponent } from "./demo/creditcardview.component";
 import { HomeComponent } from "./demo/home.component";
 import { StandardComponent } from "./demo/standard.component";
 
@@ -8,6 +9,7 @@ const routes: Routes = [
   { path: "", redirectTo: "/home", pathMatch: "full" },
   { path: "home", component: HomeComponent },
   { path: "std", component: StandardComponent },
+  { path: "ccview", component: CreditCardViewComponent },
 ];
 
 @NgModule({

--- a/demo-angular/app/demo/creditcardview.component.html
+++ b/demo-angular/app/demo/creditcardview.component.html
@@ -1,0 +1,9 @@
+<ActionBar title="CreditCardView Demo" class="action-bar">
+  <NavigationButton text=""></NavigationButton>
+</ActionBar>
+
+<StackLayout class="page">
+  <CreditCardView #card></CreditCardView>
+  <Button text="Create Token" (tap)="createToken(card)" class="btn btn-primary"></Button>
+  <Label [text]="token" textWrap="true"></Label>
+</StackLayout>

--- a/demo-angular/app/demo/creditcardview.component.ts
+++ b/demo-angular/app/demo/creditcardview.component.ts
@@ -1,0 +1,28 @@
+import { ChangeDetectorRef, Component } from "@angular/core";
+import { CreditCardView, Stripe, Token } from "nativescript-stripe";
+
+@Component({
+  selector: "stp-ccview",
+  moduleId: module.id,
+  templateUrl: "./creditcardview.component.html",
+})
+export class CreditCardViewComponent {
+  token: string;
+  private stripe: Stripe;
+
+  constructor(public changeDetectionRef: ChangeDetectorRef) {
+    this.stripe = new Stripe("pk_test_s3dHtM9w6XmgB7ak7AbCSj51");
+  }
+
+  createToken(cardView: CreditCardView): void {
+    this.token = "Fetching token...";
+    this.stripe.createToken(cardView.card, (error, token) => {
+      this.token = error ? error.message : this.formatToken(token);
+      this.changeDetectionRef.detectChanges();
+    });
+  }
+
+  private formatToken(token: Token): string {
+    return `ID: ${token.id}\nCard: ${token.card.brand} (...${token.card.last4})`;
+  }
+}

--- a/demo-angular/app/demo/home.component.html
+++ b/demo-angular/app/demo/home.component.html
@@ -4,4 +4,7 @@
 <StackLayout class="page p-10">
   <Label text="Standard Integration" class="h2"></Label>
   <Button text="Demo" [nsRouterLink]="['/std']" class="btn btn-primary btn-active"></Button>
+  <StackLayout class="hr-light m-10"></StackLayout>
+  <Label text="Custom Integration" class="h2"></Label>
+  <Button text="CreditCardView" [nsRouterLink]="['/ccview']" class="btn btn-primary btn-active"></Button>
 </StackLayout>

--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -1,10 +1,2 @@
-﻿import * as app from 'application';
-import * as platform from 'platform';
-import * as application from 'tns-core-modules/application';
-declare const STPPaymentConfiguration;
-app.on(app.launchEvent, (args) => {
-    if (platform.isIOS) {
-        STPPaymentConfiguration.sharedConfiguration().publishableKey = "pk_test_OHSX2noWHfjZMZ6uj0dbeSN7";
-    }
-});
+﻿import * as application from 'application';
 application.start({ moduleName: "main-page" });

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -1,6 +1,6 @@
+import * as observable from 'data/observable';
 import { Card, Stripe } from 'nativescript-stripe';
-import * as observable from 'tns-core-modules/data/observable';
-import * as pages from 'tns-core-modules/ui/page';
+import * as pages from 'ui/page';
 import { HelloWorldModel } from './main-view-model';
 let stripe;
 // Event handler for Page 'loaded' event attached in main-page.xml
@@ -12,7 +12,7 @@ export function pageLoaded(args: observable.EventData) {
   const card = new Card('4242424242424242', 1, 21, '111');
   if (card.validateCard()) {
     stripe = new Stripe('pk_test_OHSX2noWHfjZMZ6uj0dbeSN7');
-    stripe.createToken(card.card, (error, token) => {
+    stripe.createToken(card, (error, token) => {
       if (!error) {
         console.log(`card: ${card.brand} ...${card.last4} ${card.expMonth}/${card.expYear}`);
         console.log(`token: ${JSON.stringify(token)}`);

--- a/src/angular/index.ts
+++ b/src/angular/index.ts
@@ -1,2 +1,1 @@
-import { registerElement } from 'nativescript-angular/element-registry';
-registerElement('CreditCardView', () => require('../').CreditCardView);
+export * from "./nativescript-stripe.module";

--- a/src/angular/nativescript-stripe.directives.ts
+++ b/src/angular/nativescript-stripe.directives.ts
@@ -1,0 +1,8 @@
+import { Directive } from "@angular/core";
+
+@Directive({
+  selector: "CreditCardView"
+})
+export class CreditCardViewDirective { }
+
+export const DIRECTIVES = CreditCardViewDirective;

--- a/src/angular/nativescript-stripe.module.ts
+++ b/src/angular/nativescript-stripe.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from "@angular/core";
+import { registerElement } from "nativescript-angular/element-registry";
+import { DIRECTIVES } from "./nativescript-stripe.directives";
+
+@NgModule({
+  declarations: [DIRECTIVES],
+  exports: [DIRECTIVES],
+})
+export class CreditCardViewModule { }
+
+registerElement("CreditCardView", () => require("../").CreditCardView);

--- a/src/angular/package.json
+++ b/src/angular/package.json
@@ -1,3 +1,4 @@
 {
-    "main": "index"
+  "name": "nativescript-stripe",
+  "main": "index.js"
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,14 +1,11 @@
 import { CreditCardViewBase } from './stripe.common';
 export declare class Stripe {
-    private _stripe;
     constructor(apiKey: string);
-    createToken(card: any /*Card.card*/, cb: (error: Error, token: Token) => void): void;
+    createToken(card: CardCommon, cb: (error: Error, token: Token) => void): void;
 }
-export declare class Card {
-    _card: any;
-    constructor(cardNumber: string, cardExpMonth: number, cardExpYear: number, cardCVC: string);
-    static fromNative(card: any): Card;
-    readonly card: any /*ios:STPCardParams, android:com.stripe.android.model.Card*/;
+export declare type CardBrand = "Visa" | "Amex" | "MasterCard" | "Discover" | "JCB" | "DinersClub" | "Unknown";
+export declare interface CardCommon {
+    readonly native: any;
     validateNumber(): boolean;
     validateCVC(): boolean;
     validateCard(): boolean;
@@ -32,7 +29,34 @@ export declare class Card {
     readonly funding: string;
     readonly country: string;
 }
-export declare class CreditCardView extends CreditCardViewBase {
+export declare class Card implements CardCommon {
+    static fromNative(card: any): Card;
+    constructor(cardNumber: string, expMonth: number, expYear: number, cardCVC: string);
+    readonly native: any;
+    validateNumber(): boolean;
+    validateCVC(): boolean;
+    validateCard(): boolean;
+    validateExpMonth(): boolean;
+    validateExpiryDate(): boolean;
+    readonly number: string;
+    readonly cvc: string;
+    readonly expMonth: number;
+    readonly expYear: number;
+    name: string;
+    addressLine1: string;
+    addressLine2: string;
+    addressCity: string;
+    addressZip: string;
+    addressState: string;
+    addressCountry: string;
+    currency: string;
+    readonly last4: string;
+    readonly brand: CardBrand;
+    readonly fingerprint: string;
+    readonly funding: string;
+    readonly country: string;
+  }
+  export declare class CreditCardView extends CreditCardViewBase {
     readonly android: any /*com.stripe.android.view.CardInputWidget*/;
     createNativeView(): any /*ios:STPPaymentCardTextField, android:com.stripe.android.view.CardInputWidget*/;
     readonly card: Card;
@@ -40,7 +64,7 @@ export declare class CreditCardView extends CreditCardViewBase {
 export interface Token {
     id: string;
     bankAccount: any;
-    card: Card;
+    card: CardCommon;
     created: Date;
     ios: any /*STPToken*/;
     android: any /*com.stripe.android.model.Token*/;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-stripe",
-    "version": "4.2.0",
+    "version": "5.0.0",
     "description": "NativeScript Stripe sdk",
     "main": "stripe.js",
     "typings": "index.d.ts",

--- a/src/package.json
+++ b/src/package.json
@@ -1,8 +1,8 @@
 {
     "name": "nativescript-stripe",
-    "version": "4.1.1",
+    "version": "4.2.0",
     "description": "NativeScript Stripe sdk",
-    "main": "stripe",
+    "main": "stripe.js",
     "typings": "index.d.ts",
     "nativescript": {
         "platforms": {

--- a/src/stripe.android.ts
+++ b/src/stripe.android.ts
@@ -1,5 +1,5 @@
-import * as utils from 'tns-core-modules/utils/utils';
-import { CardBrand, CreditCardViewBase, Token } from './stripe.common';
+import * as utils from 'utils/utils';
+import { CardBrand, CardCommon, CreditCardViewBase, Token } from './stripe.common';
 export class Stripe {
   private _stripe: com.stripe.android.Stripe;
   constructor(apiKey: string) {
@@ -9,17 +9,22 @@ export class Stripe {
     );
   }
 
-  public createToken(card: com.stripe.android.model.Card, cb: (error: Error, token: Token) => void): void {
-    const that = new WeakRef(this);
+  public createToken(card: CardCommon, cb: (error: Error, token: Token) => void): void {
+    if (!card) {
+      if (typeof cb === 'function') {
+        cb(new Error('Invalid card'), null);
+      }
+      return;
+    }
     this._stripe.createToken(
-      card,
+      card.native,
       new com.stripe.android.TokenCallback({
         onSuccess: function(token) {
           if (typeof cb === 'function') {
             const newToken: Token = {
               id: token.getId(),
               bankAccount: token.getBankAccount(),
-              card: Card.fromNative(card),
+              card: Card.fromNative(token.getCard()),
               created: new Date(token.getCreated().toString()),
               livemode: token.getLivemode(),
               android: token,
@@ -38,8 +43,8 @@ export class Stripe {
   }
 }
 
-export class Card {
-  _card: com.stripe.android.model.Card;
+export class Card implements CardCommon {
+  native: com.stripe.android.model.Card;
   constructor(
     cardNumber: string,
     cardExpMonth: number,
@@ -47,7 +52,7 @@ export class Card {
     cardCVC: string
   ) {
     if (cardNumber && cardExpMonth && cardExpYear && cardCVC) {
-      this._card = new com.stripe.android.model.Card(
+      this.native = new com.stripe.android.model.Card(
         cardNumber,
         new java.lang.Integer(cardExpMonth),
         new java.lang.Integer(cardExpYear),
@@ -58,121 +63,117 @@ export class Card {
 
   public static fromNative(card: com.stripe.android.model.Card): Card {
     const newCard = new Card(null, null, null, null);
-    newCard._card = card;
+    newCard.native = card;
     return newCard;
   }
 
-  get card(): com.stripe.android.model.Card {
-    return this._card;
-  }
-
   validateNumber(): boolean {
-    return this._card.validateNumber();
+    return this.native.validateNumber();
   }
   validateCVC(): boolean {
-    return this._card.validateCVC();
+    return this.native.validateCVC();
   }
   validateCard(): boolean {
-    return this._card.validateCard();
+    return this.native.validateCard();
   }
   validateExpMonth(): boolean {
-    return this._card.validateExpMonth();
+    return this.native.validateExpMonth();
   }
   validateExpiryDate(): boolean {
-    return this._card.validateExpiryDate();
+    return this.native.validateExpiryDate();
   }
   get number(): string {
-    return this._card.getNumber();
+    return this.native.getNumber();
   }
   get cvc(): string {
-    return this._card.getCVC();
+    return this.native.getCVC();
   }
   get expMonth(): number {
-    return this._card.getExpMonth().intValue();
+    return this.native.getExpMonth().intValue();
   }
   get expYear(): number {
-    return this._card.getExpYear().intValue();
+    return this.native.getExpYear().intValue();
   }
   get name(): string {
-    return this._card.getName();
+    return this.native.getName();
   }
   set name(value: string) {
-    this._card.setName(value);
+    this.native.setName(value);
   }
 
   get addressLine1(): string {
-    return this._card.getAddressLine1();
+    return this.native.getAddressLine1();
   }
 
   set addressLine1(value: string) {
-    this._card.setAddressLine1(value);
+    this.native.setAddressLine1(value);
   }
 
   get addressLine2(): string {
-    return this._card.getAddressLine2();
+    return this.native.getAddressLine2();
   }
   set addressLine2(value: string) {
-    this._card.setAddressLine2(value);
+    this.native.setAddressLine2(value);
   }
 
   get addressCity(): string {
-    return this._card.getAddressCity();
+    return this.native.getAddressCity();
   }
 
   set addressCity(value: string) {
-    this._card.setAddressCity(value);
+    this.native.setAddressCity(value);
   }
 
   get addressZip(): string {
-    return this._card.getAddressZip();
+    return this.native.getAddressZip();
   }
 
   set addressZip(value: string) {
-    this._card.setAddressZip(value);
+    this.native.setAddressZip(value);
   }
 
   get addressState(): string {
-    return this._card.getAddressState();
+    return this.native.getAddressState();
   }
 
   set addressState(value: string) {
-    this._card.setAddressState(value);
+    this.native.setAddressState(value);
   }
 
   get addressCountry(): string {
-    return this._card.getAddressCountry();
+    return this.native.getAddressCountry();
   }
 
   set addressCountry(value: string) {
-    this._card.setAddressCountry(value);
+    this.native.setAddressCountry(value);
   }
 
   get currency(): string {
-    return this._card.getCurrency();
+    return this.native.getCurrency();
   }
 
   set currency(value: string) {
-    this._card.setCurrency(value);
+    this.native.setCurrency(value);
   }
 
   get last4(): string {
-    return this._card.getLast4();
+    return this.native.getLast4();
   }
 
   get brand(): CardBrand {
-    return <CardBrand>this._card.getBrand();
+    return <CardBrand>this.native.getBrand();
   }
 
   get fingerprint(): string {
-    return this._card.getFingerprint();
+    return this.native.getFingerprint();
   }
 
   get funding(): string {
-    return this._card.getFunding();
+    return this.native.getFunding();
   }
 
   get country(): string {
-    return this._card.getCountry();
+    return this.native.getCountry();
   }
 }
 

--- a/src/stripe.common.ts
+++ b/src/stripe.common.ts
@@ -1,7 +1,6 @@
-import { View } from 'tns-core-modules/ui/core/view';
-import { Card } from '.';
+import { View } from 'ui/core/view';
 
-export class CreditCardViewBase extends View {}
+export class CreditCardViewBase extends View { }
 
 export type CardBrand =
   | 'Visa'
@@ -12,10 +11,36 @@ export type CardBrand =
   | 'DinersClub'
   | 'Unknown';
 
+export interface CardCommon {
+  readonly native: any;
+  validateNumber(): boolean;
+  validateCVC(): boolean;
+  validateCard(): boolean;
+  validateExpMonth(): boolean;
+  validateExpiryDate(): boolean;
+  readonly number: string;
+  readonly cvc: string;
+  readonly expMonth: number;
+  readonly expYear: number;
+  name: string;
+  addressLine1: string;
+  addressLine2: string;
+  addressCity: string;
+  addressZip: string;
+  addressState: string;
+  addressCountry: string;
+  currency: string;
+  readonly last4: string;
+  readonly brand: CardBrand;
+  readonly fingerprint: string;
+  readonly funding: string;
+  readonly country: string;
+}
+
 export interface Token {
   id: string;
   bankAccount: any;
-  card: Card;
+  card: CardCommon;
   created: Date;
   ios: any;
   android: any;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the new behavior?
Add a demo of Custom Integration's CreditCardView to the `demo-angular` app.

This updates the way the plugin supports Angular to follow the [new guidelines](https://docs.nativescript.org/angular/plugins/angular-plugin).

This makes some changes to the Custom Integration API to make it similar across platforms:

* `Card` now implements a new interface `CardCommon`
* `Stripe.createToken` now takes a `Card` (or `CardCommon`) instead of a native object
* `Card.card` has been replaced with `Card.native`

Closes #24 

BREAKING CHANGES:

See above. APIs for registering in Angular and `createToken` have changed.

Migration steps:

* Follow the instructions in the README for using Angular.
* Change all calls to `Stripe.createToken` to take `card` instead of `card.card`.
* If you use the native interface (`card.card`) consider using `CardCommon` instead. If you still need the native interface, change `card.card` to `card.native`.
