### PR TITLE
fix(callback-payment-ready): set isReadyToCharge in paymentDataChanged callback on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ==============================
 
+## 5.0.1 (2018, October 20)
+### Fixes
+- [(#30)](https://github.com/triniwiz/nativescript-stripe/issues/30) Standard Integration on iOS fails to send "payment ready" status
+
 ## 5.0.0 (2018, October 17)
 ### Additions
 - [(# 24)](https://github.com/triniwiz/nativescript-stripe/issues/24) Add Support for Custom Integration to Angular demo

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-stripe",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "description": "NativeScript Stripe sdk",
     "main": "stripe.js",
     "typings": "index.d.ts",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
In paymentDataChanged callback on iOS, `isReadyToCharge` always returns `false`.

## What is the new behavior?
It now returns the correct state.

Fixes #30 .

(Also, removes some dead code.)