### PR TITLE
fix(typings): fix type definition of CreditCardViewBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ==============================
 
+## 5.0.3 (2018, November 17)
+### Fixes
+- [(# 35)](https://github.com/triniwiz/nativescript-stripe/issues/35) index.d.ts does not properly define CreditCardViewBase.
+
 ## 5.0.2 (2018, October 20)
 ### Additions
 - [(# 25)](https://github.com/triniwiz/nativescript-stripe/issues/25) Add Support for Standard Integration to demo. The demo app now matches the demo-angular app.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,6 @@
-import { CreditCardViewBase } from './stripe.common';
+import { View } from "ui/core/view";
+
+export declare class CreditCardViewBase extends View { }
 export declare class Stripe {
     constructor(apiKey: string);
     createToken(card: CardCommon, cb: (error: Error, token: Token) => void): void;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-stripe",
-    "version": "5.0.2",
+    "version": "5.0.3",
     "description": "NativeScript Stripe sdk",
     "main": "stripe.js",
     "typings": "index.d.ts",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
In `index.ts` the class `CreditCardViewBase` is declared via an import to .js file which has no type info. Therefore, the fact that `CreditCardViewBase` is a `View` is not available to Typescript.

## What is the new behavior?
`index.ts` is fixed to explicitly declare `CreditCardViewBase`.

Fixes #35 .