### PR TITLE
fix(travis-ci): fix Android Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ android:
     - tools
     - platform-tools
     - build-tools-27.0.3
-    - android-27
+    - build-tools-28.0.3
+    - android-28
     - android-26
     - android-23
     - extra-android-m2repository


### PR DESCRIPTION
## What is the current behavior?
Android builds on Travis CI are failing during initial run of `tns`. This is not related to the code but instead to the development environment.

## What is the new behavior?
Builds pass.
