### PR TITLE
fix(android-source): fix usage of CustomerSource on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ==============================
 
+## 5.0.6 (2018, December 21)
+### Fixes
+- [(# 39)](https://github.com/triniwiz/nativescript-stripe/issues/39) Standard Integration: Error referencing null 'source' from CustomerSource object.
+
 ## 5.0.5 (2018, December 20)
 ### Fixes
 - [(# 40)](https://github.com/triniwiz/nativescript-stripe/issues/40) Standard Integration: When user cancels, no message is sent to listener.

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nativescript-stripe",
-    "version": "5.0.5",
+    "version": "5.0.6",
     "description": "NativeScript Stripe sdk",
     "main": "stripe.js",
     "typings": "index.d.ts",

--- a/src/standard/standard.android.ts
+++ b/src/standard/standard.android.ts
@@ -221,7 +221,14 @@ function createPaymentMethod(customer: com.stripe.android.model.Customer, paymen
   let cs = customer.getSourceById(paymentMethodId);
   if (!cs) return { label: "Error (102)", image: undefined, templateImage: undefined };
   let source = cs.asSource();
+  let card = cs.asCard();
 
+  if (source) return createPaymentMethodFromSource(source);
+  if (card) return createPaymentMethodFromCard(card);
+  return { label: "Error (103)", image: undefined, templateImage: undefined };
+}
+
+function createPaymentMethodFromSource(source: com.stripe.android.model.Source): StripePaymentMethod {
   let label: string;
   let image: any;
   if (source.getType() === com.stripe.android.model.Source.CARD) {
@@ -231,6 +238,16 @@ function createPaymentMethod(customer: com.stripe.android.model.Customer, paymen
   } else {
     label = source.getType();
   }
+  return {
+    label: label,
+    image: image,
+    templateImage: undefined
+  };
+}
+
+function createPaymentMethodFromCard(card: com.stripe.android.model.Card): StripePaymentMethod {
+  let label = `${card.getBrand()} ...${card.getLast4()}`;
+  let image = getBitmapFromResource(com.stripe.android.model.Card.BRAND_RESOURCE_MAP.get(card.getBrand()).longValue());
   return {
     label: label,
     image: image,


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Usage of `CustomerSource.asSource` on Android works in some cases but in others it crashes accessing `undefined` or `null`. Apparently you need to retrieve the credit card info either `asSource` or `asCard` to make sure you correctly handle all cases.

## What is the new behavior?
It checks both `asSource` and `asCard` and uses whichever one is non-null. If neither is non-null, it returns a Card with label 'Error(103)'.

Fixes #39 .
