### PR TITLE
feat(prefill_address): prefill shipping address in StripePaymentSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ==============================
 
+## 5.4.0 (2019, June 12)
+### Fixes
+- [(# 70)](https://github.com/triniwiz/nativescript-stripe/issues/70) Support prefilled shipping address in StripePaymentSession
+
 ## 5.3.3 (2019, May 13)
 ### Fixes
 - [(# 63)](https://github.com/triniwiz/nativescript-stripe/issues/63) Properly handle no shipping method or address

--- a/demo/app/App_Resources/Android/app.gradle
+++ b/demo/app/App_Resources/Android/app.gradle
@@ -5,12 +5,12 @@
 //	compile 'com.android.support:recyclerview-v7:+'
 //}
 
-android {  
-  defaultConfig {  
+android {
+  defaultConfig {
     generatedDensities = []
-    applicationId = "org.nativescript.demo"  
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+    applicationId = "org.nativescript.stripe.demo"
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-stripe",
-  "version": "5.3.3",
+  "version": "5.4.0",
   "description": "NativeScript Stripe sdk",
   "main": "stripe",
   "typings": "index.d.ts",

--- a/src/standard/index.d.ts
+++ b/src/standard/index.d.ts
@@ -65,7 +65,8 @@ export declare class StripePaymentSession {
     customerSession: StripeCustomerSession,
     amount: number,
     currency: string,
-    listener: StripePaymentListener);
+    listener: StripePaymentListener,
+    prefilledAddress?: StripeAddress);
   /** Is the native component loading? */
   readonly loading: boolean;
   /** Has user entered enough info that a charge can be made? */
@@ -100,15 +101,15 @@ export declare interface StripePaymentData {
   shippingInfo: StripeShippingMethod;
 }
 export declare interface StripeAddress {
-  name: string;
-  line1: string;
-  line2: string;
-  city: string;
-  state: string;
-  postalCode: string;
-  country: string;
-  phone: string;
-  email: string;
+  name?: string;
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+  phone?: string;
+  email?: string;
 }
 export declare interface StripeShippingMethods {
   /** Is shipping to the address valid? */

--- a/src/standard/standard.common.ts
+++ b/src/standard/standard.common.ts
@@ -90,15 +90,15 @@ export interface StripeShippingMethods {
 }
 
 export interface StripeAddress {
-  name: string;
-  line1: string;
-  line2: string;
-  city: string;
-  state: string;
-  postalCode: string;
-  country: string;
-  phone: string;
-  email: string;
+  name?: string;
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+  phone?: string;
+  email?: string;
 }
 
 export const enum StripeBillingAddressFields {

--- a/src/standard/standard.ios.ts
+++ b/src/standard/standard.ios.ts
@@ -80,13 +80,27 @@ export class StripePaymentSession {
     customerSession: StripeCustomerSession,
     amount: number,
     currency: string,
-    listener?: StripePaymentListener) {
+    listener?: StripePaymentListener,
+    prefilledAddress?: StripeAddress) {
     this.native = STPPaymentContext.alloc()
       .initWithCustomerContextConfigurationTheme(
         customerSession.native,
         StripeConfig.shared().native,
         STPTheme.defaultTheme());
     this.native.prefilledInformation = STPUserInformation.alloc().init();
+    if (prefilledAddress) {
+      const addr = STPAddress.alloc().init();
+      addr.name = prefilledAddress.name;
+      addr.line1 = prefilledAddress.line1;
+      addr.line2 = prefilledAddress.line2;
+      addr.city = prefilledAddress.city;
+      addr.state = prefilledAddress.state;
+      addr.country = prefilledAddress.country;
+      addr.postalCode = prefilledAddress.postalCode;
+      addr.phone = prefilledAddress.phone;
+      addr.email = prefilledAddress.email;
+      this.native.prefilledInformation.shippingAddress = addr;
+    }
     this.native.paymentAmount = amount;
     this.native.paymentCurrency = currency;
     if (listener) {


### PR DESCRIPTION
## What is the current behavior?
In the standard integration, you cannot provide a prefilled shipping address to StripePaymentSession even though Stripe mobile SDKs support this.

## What is the new behavior?
Prefilled shipping address is supported.

Implements #70.