### PR TITLE
fix(ios/deprecated_ios.getter): remove calls to deprecated utils.ios.getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ==============================
 
+## 5.4.2 (2019, June 28)
+### Implements
+- [(# 75)](https://github.com/triniwiz/nativescript-stripe/issues/75) Remove calls to deprecated utils.ios.getter.
+
 ## 5.4.1 (2019, June 14)
 ### Implements
 - [(# 71)](https://github.com/triniwiz/nativescript-stripe/issues/71) Provide more info to Listener callback

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-stripe",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "NativeScript Stripe sdk",
   "main": "stripe",
   "typings": "index.d.ts",

--- a/src/stripe.ios.ts
+++ b/src/stripe.ios.ts
@@ -1,5 +1,4 @@
 import { View } from 'tns-core-modules/ui/core/view';
-import { ios } from 'tns-core-modules/utils/utils';
 import { CardBrand, CardCommon, CreditCardViewBase, PaymentMethodCommon, StripePaymentIntentCommon, StripePaymentIntentStatus, Token } from './stripe.common';
 
 export class Stripe {
@@ -14,7 +13,7 @@ export class Stripe {
       }
       return;
     }
-    const apiClient = ios.getter(STPAPIClient, STPAPIClient.sharedClient);
+    const apiClient = STPAPIClient.sharedClient();
     apiClient.createTokenWithCardCompletion(
       card.native,
       callback(cb, (token) => <Token>{
@@ -36,7 +35,7 @@ export class Stripe {
       }
       return;
     }
-    const apiClient = ios.getter(STPAPIClient, STPAPIClient.sharedClient);
+    const apiClient = STPAPIClient.sharedClient();
     const cardParams = STPPaymentMethodCardParams.new();
     if (card.cvc) cardParams.cvc = card.cvc;
     if (card.expMonth) cardParams.expMonth = card.expMonth;
@@ -57,7 +56,7 @@ export class Stripe {
   }
 
   retrievePaymentIntent(clientSecret: string, cb: (error: Error, pm: StripePaymentIntent) => void): void {
-    const apiClient = ios.getter(STPAPIClient, STPAPIClient.sharedClient);
+    const apiClient = STPAPIClient.sharedClient();
     apiClient.retrievePaymentIntentWithClientSecretCompletion(
       clientSecret,
       callback(cb, (pi) => StripePaymentIntent.fromNative(pi))
@@ -65,7 +64,7 @@ export class Stripe {
   }
 
   confirmPaymentIntent(pi: StripePaymentIntent, returnUrl: string, cb: (error: Error, pm: StripePaymentIntent) => void): void {
-    const apiClient = ios.getter(STPAPIClient, STPAPIClient.sharedClient);
+    const apiClient = STPAPIClient.sharedClient();
     const params = STPPaymentIntentParams.alloc().initWithClientSecret(pi.clientSecret);
     params.returnURL = returnUrl;
     apiClient.confirmPaymentIntentWithParamsCompletion(


### PR DESCRIPTION
Removes calls in IOS implementation to `utils.ios.getter`, which has been deprecated. Now makes calls directly to the native library.

Fixes/Implements/Closes #75.
