### PR TITLE
fix(NS6-build): Fix NS v6 Build Problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,12 @@ matrix:
       os: osx
       env:
         - WebPack="iOS"
-      osx_image: xcode11
+      osx_image: xcode11.2
       language: node_js
       node_js: "11"
       jdk: oraclejdk8
       before_install:
+        - travis_wait pod --version
         - travis_wait pod repo update --silent
       script:
         - cd src && npm i
@@ -41,11 +42,12 @@ matrix:
       env:
         - BuildiOS="11"
         - Xcode="11.0"
-      osx_image: xcode11
+      osx_image: xcode11.2
       language: node_js
       node_js: "11"
       jdk: oraclejdk8
       before_install:
+        - travis_wait pod --version
         - travis_wait pod repo update --silent
       script:
         - cd src && npm i && npm run tsc && cd ../demo && tns build ios && cd ../demo-angular && tns build ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
       node_js: "11"
       jdk: oraclejdk8
       before_install:
+        - travis_wait pip install six
         - travis_wait gem install cocoapods
-        - travis_wait pod --version
         - travis_wait pod repo update --silent
       script:
         - cd src && npm i
@@ -48,8 +48,8 @@ matrix:
       node_js: "11"
       jdk: oraclejdk8
       before_install:
+        - travis_wait pip install six
         - travis_wait gem install cocoapods
-        - travis_wait pod --version
         - travis_wait pod repo update --silent
       script:
         - cd src && npm i && npm run tsc && cd ../demo && tns build ios && cd ../demo-angular && tns build ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
       node_js: "11"
       jdk: oraclejdk8
       before_install:
+        - travis_wait gem install cocoapods
         - travis_wait pod --version
         - travis_wait pod repo update --silent
       script:
@@ -47,6 +48,7 @@ matrix:
       node_js: "11"
       jdk: oraclejdk8
       before_install:
+        - travis_wait gem install cocoapods
         - travis_wait pod --version
         - travis_wait pod repo update --silent
       script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 Changelog
 
+## 6.2.0 (2019, November 16)
+### Updates
+- Builds correctly on NS v6 (see README note)
+
+### Fixes
+- [(# 90)](https://github.com/triniwiz/nativescript-stripe/issues/90) Not building with NS 6
+
 ## 6.1.0 (2019, November 6)
 ### Updates
 - Ability to set accountId `stripe.setStripeAccount('xxx')`

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ If you're using the [manual confirmation flow](https://stripe.com/docs/payments/
 ## Status
 `demo-angular` now supports `SetupIntent` and `PaymentIntent` SCA integration. Any credit card verification will be automatically prompted to the user.
 
+# Known Issues
+
+## `const enum` not found
+When building with NativeScript v6, it builds using the webpack-only flow in "transpileOnly" mode. A webpack [issue](https://github.com/NativeScript/nativescript-dev-webpack/issues/927) means that `const enum` values cannot be found in the final output.
+
+This problem is not present in Angular projects and likely won't be an issue if you do not use any of the exported enums.
+
+Unfortunately, the only fix I've found for this is to follow the advice in that issue and modify `webpack.config.js` in your app to set `transpileOnly` to `false`.
+
 # TODO
 * Android Pay
 * Apple Pay (supported by Standard Integration, not by Custom Integration)

--- a/demo-angular/package.json
+++ b/demo-angular/package.json
@@ -6,10 +6,10 @@
   "nativescript": {
     "id": "org.nativescript.stripe.demoangular",
     "tns-ios": {
-      "version": "6.0.1"
+      "version": "6.2.0"
     },
     "tns-android": {
-      "version": "6.0.0"
+      "version": "6.2.0"
     }
   },
   "dependencies": {
@@ -27,7 +27,7 @@
     "nativescript-theme-core": "~1.0.4",
     "reflect-metadata": "~0.1.12",
     "rxjs": "^6.3.3",
-    "tns-core-modules": "6.0.1",
+    "tns-core-modules": "~6.2.0",
     "zone.js": "0.9.1"
   },
   "devDependencies": {
@@ -38,7 +38,7 @@
     "babylon": "6.18.0",
     "lazy": "1.0.11",
     "nativescript-css-loader": "~0.26.1",
-    "nativescript-dev-webpack": "1.0.1",
+    "nativescript-dev-webpack": "~1.3.0",
     "tns-platform-declarations": "6.0.1",
     "tslint": "~5.4.3",
     "typescript": "3.4.5"

--- a/demo-angular/tsconfig.tns.json
+++ b/demo-angular/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/demo-angular/webpack.config.js
+++ b/demo-angular/webpack.config.js
@@ -7,6 +7,7 @@ const { nsReplaceBootstrap } = require("nativescript-dev-webpack/transformers/ns
 const { nsReplaceLazyLoader } = require("nativescript-dev-webpack/transformers/ns-replace-lazy-loader");
 const { nsSupportHmrNg } = require("nativescript-dev-webpack/transformers/ns-support-hmr-ng");
 const { getMainModulePath } = require("nativescript-dev-webpack/utils/ast-utils");
+const { getNoEmitOnErrorFromTSConfig } = require("nativescript-dev-webpack/utils/tsconfig-utils");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
@@ -35,10 +36,9 @@ module.exports = env => {
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
-        // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
-        appPath = "app",
-        appResourcesPath = "app/App_Resources",
+        // the nsconfig.json configuration file.
+        appPath = "src",
+        appResourcesPath = "App_Resources",
 
         // You can provide the following flags when running 'tns run android|ios'
         aot, // --env.aot
@@ -51,8 +51,12 @@ module.exports = env => {
         hmr, // --env.hmr,
         unitTesting, // --env.unitTesting
         verbose, // --env.verbose
+        snapshotInDocker, // --env.snapshotInDocker
+        skipSnapshotTools, // --env.skipSnapshotTools
+        compileSnapshot // --env.compileSnapshot
     } = env;
 
+    const useLibs = compileSnapshot;
     const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
     const externals = nsWebpack.getConvertedExternals(env.externals);
     const appFullPath = resolve(projectRoot, appPath);
@@ -108,6 +112,8 @@ module.exports = env => {
         itemsToClean.push(`${join(projectRoot, "platforms", "android", "app", "build", "configurations", "nativescript-android-snapshot")}`);
     }
 
+    const noEmitOnErrorFromTSConfig = getNoEmitOnErrorFromTSConfig(join(projectRoot, tsConfigName));
+
     nsWebpack.processAppComponents(appComponents, platform);
     const config = {
         mode: production ? "production" : "development",
@@ -159,6 +165,7 @@ module.exports = env => {
         devtool: hiddenSourceMap ? "hidden-source-map" : (sourceMap ? "inline-source-map" : "none"),
         optimization: {
             runtimeChunk: "single",
+            noEmitOnErrors: noEmitOnErrorFromTSConfig,
             splitChunks: {
                 cacheGroups: {
                     vendor: {
@@ -197,7 +204,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {
@@ -221,19 +228,24 @@ module.exports = env => {
 
                 { test: /\.html$|\.xml$/, use: "raw-loader" },
 
-                // tns-core-modules reads the app.css and its imports using css-loader
                 {
                     test: /[\/|\\]app\.css$/,
                     use: [
                         "nativescript-dev-webpack/style-hot-loader",
-                        { loader: "css-loader", options: { url: false } }
+                        {
+                            loader: "nativescript-dev-webpack/css2json-loader",
+                            options: { useForImports: true }
+                        }
                     ]
                 },
                 {
                     test: /[\/|\\]app\.scss$/,
                     use: [
                         "nativescript-dev-webpack/style-hot-loader",
-                        { loader: "css-loader", options: { url: false } },
+                        {
+                            loader: "nativescript-dev-webpack/css2json-loader",
+                            options: { useForImports: true }
+                        },
                         "sass-loader"
                     ]
                 },
@@ -309,6 +321,9 @@ module.exports = env => {
             ],
             projectRoot,
             webpackConfig: config,
+            snapshotInDocker,
+            skipSnapshotTools,
+            useLibs
         }));
     }
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,17 +2,17 @@
   "nativescript": {
     "id": "org.nativescript.stripe.demo",
     "tns-ios": {
-      "version": "6.0.1"
+      "version": "6.2.0"
     },
     "tns-android": {
-      "version": "6.0.0"
+      "version": "6.2.0"
     }
   },
   "dependencies": {
     "nativescript-stripe": "file:../src",
     "nativescript-theme-core": "^1.0.4",
     "nativescript-unit-test-runner": "0.7.0",
-    "tns-core-modules": "6.0.1"
+    "tns-core-modules": "~6.2.0"
   },
   "devDependencies": {
     "awesome-typescript-loader": "~5.2.1",
@@ -27,7 +27,7 @@
     "karma-nativescript-launcher": "^0.4.0",
     "lazy": "1.0.11",
     "nativescript-css-loader": "~0.26.0",
-    "nativescript-dev-webpack": "1.0.1",
+    "nativescript-dev-webpack": "~1.3.0",
     "tns-platform-declarations": "6.0.1",
     "tslint": "~5.4.3",
     "typescript": "3.4.5",

--- a/demo/tsconfig.tns.json
+++ b/demo/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -3,6 +3,7 @@ const { join, relative, resolve, sep } = require("path");
 const webpack = require("webpack");
 const nsWebpack = require("nativescript-dev-webpack");
 const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target");
+const { getNoEmitOnErrorFromTSConfig } = require("nativescript-dev-webpack/utils/tsconfig-utils");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
@@ -31,8 +32,7 @@ module.exports = env => {
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
-        // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
+        // the nsconfig.json configuration file.
         appPath = "app",
         appResourcesPath = "app/App_Resources",
 
@@ -46,7 +46,12 @@ module.exports = env => {
         hmr, // --env.hmr,
         unitTesting, // --env.unitTesting,
         verbose, // --env.verbose
+        snapshotInDocker, // --env.snapshotInDocker
+        skipSnapshotTools, // --env.skipSnapshotTools
+        compileSnapshot // --env.compileSnapshot
     } = env;
+
+    const useLibs = compileSnapshot;
     const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
     const externals = nsWebpack.getConvertedExternals(env.externals);
 
@@ -71,6 +76,8 @@ module.exports = env => {
         itemsToClean.push(`${join(projectRoot, "platforms", "android", "app", "src", "main", "assets", "snapshots")}`);
         itemsToClean.push(`${join(projectRoot, "platforms", "android", "app", "build", "configurations", "nativescript-android-snapshot")}`);
     }
+
+    const noEmitOnErrorFromTSConfig = getNoEmitOnErrorFromTSConfig(tsConfigPath);
 
     nsWebpack.processAppComponents(appComponents, platform);
     const config = {
@@ -125,6 +132,7 @@ module.exports = env => {
         devtool: hiddenSourceMap ? "hidden-source-map" : (sourceMap ? "inline-source-map" : "none"),
         optimization: {
             runtimeChunk: "single",
+            noEmitOnErrors: noEmitOnErrorFromTSConfig,
             splitChunks: {
                 cacheGroups: {
                     vendor: {
@@ -164,7 +172,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {
@@ -184,7 +192,7 @@ module.exports = env => {
                         },
                     ].filter(loader => !!loader)
                 },
-                
+
                 {
                     test: /\.(ts|css|scss|html|xml)$/,
                     use: "nativescript-dev-webpack/hmr/hot-loader"
@@ -194,13 +202,13 @@ module.exports = env => {
 
                 {
                     test: /\.css$/,
-                    use: { loader: "css-loader", options: { url: false } }
+                    use: "nativescript-dev-webpack/css2json-loader"
                 },
 
                 {
                     test: /\.scss$/,
                     use: [
-                        { loader: "css-loader", options: { url: false } },
+                        "nativescript-dev-webpack/css2json-loader",
                         "sass-loader"
                     ]
                 },
@@ -254,6 +262,7 @@ module.exports = env => {
                 tsconfig: tsConfigPath,
                 async: false,
                 useTypescriptIncrementalApi: true,
+                checkSyntacticErrors: true,
                 memoryLimit: 4096
             })
         ],
@@ -278,6 +287,9 @@ module.exports = env => {
             ],
             projectRoot,
             webpackConfig: config,
+            snapshotInDocker,
+            skipSnapshotTools,
+            useLibs
         }));
     }
 

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-stripe",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "description": "NativeScript Stripe sdk",
   "main": "stripe",
   "typings": "index.d.ts",

--- a/src/standard/index.d.ts
+++ b/src/standard/index.d.ts
@@ -137,7 +137,7 @@ export declare const enum StripeBillingAddressFields {
   Name = 3
 }
 /** Available shipping address fields. */
-export const enum StripeShippingAddressField {
+export declare const enum StripeShippingAddressField {
   Name = "name",
   PostalAddress = "address",
   Phone = "phone",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests are passing
- [x] Tests for the changes are included

## What is the current behavior?
Build breaks on NS v6 because WebPack cannot inline `const enum`s using `transpileOnly` option.

## What is the new behavior?
Client code that uses the enums must change `transpileOnly` in `webpack.config.js` to `false`.

Fixes/Implements/Closes #90 .

Client code that uses the enums must change `transpileOnly` in `webpack.config.js` to `false`.
Note that Angular builds do not need to make any changes since they do not have a `transpileOnly` mode.