### PR TITLE
fix(pmt-sess-config): re-reads Config when creating new PaymentSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+## 6.3.1 (2020, April 1)
+### Fixes
+- [(# 101)](https://github.com/triniwiz/nativescript-stripe/issues/101) PaymentSession Doesn't Reread Config. Re-reads StripeConfig when a new PaymentSession is created.
+
 ## 6.3.0 (2020, March 30)
 ### Fixes
 - [(# 97)](https://github.com/triniwiz/nativescript-stripe/issues/97) IOS Build Failed (Xcode >= 11.3). This was fixed by upgrading to Stripe iOS SDK 19.0.1 (from SDK 16.0.6). No code changes were made. This release does not specifically use any new features of SDK 17, 18, or 19. Note that Stripe SDK 19 requires Apple iOS platform 10 or greater (currently supported by > 95% of all iOS devices).

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-stripe",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "NativeScript Stripe sdk",
   "main": "stripe",
   "typings": "index.d.ts",

--- a/src/standard/standard.android.ts
+++ b/src/standard/standard.android.ts
@@ -12,22 +12,9 @@ function useAndroidX() {
 }
 
 export class StripeConfig extends StripeConfigCommon {
-  private _native: com.stripe.android.PaymentSessionConfig;
   private _paymentConfigurationInitiated: boolean = false;
   get native(): com.stripe.android.PaymentSessionConfig {
     // getter gives client a chance to set properties before using.
-    if (!this._native) this._native = this.toNative();
-    return this._native;
-  }
-
-  initPaymentConfiguration(): void {
-    if (!this.publishableKey) throw new Error("publishableKey must be set");
-    if (this._paymentConfigurationInitiated) return;
-    com.stripe.android.PaymentConfiguration.init(this.publishableKey);
-    this._paymentConfigurationInitiated = true;
-  }
-
-  private toNative(): com.stripe.android.PaymentSessionConfig {
     this.initPaymentConfiguration();
     let optionalFields = [];
     if (this.requiredShippingAddressFields.indexOf(StripeShippingAddressField.PostalAddress) < 0) {
@@ -48,6 +35,13 @@ export class StripeConfig extends StripeConfigCommon {
       .setOptionalShippingInfoFields(optionalFields)
       .build();
     return config;
+  }
+
+  initPaymentConfiguration(): void {
+    if (!this.publishableKey) throw new Error("publishableKey must be set");
+    if (this._paymentConfigurationInitiated) return;
+    com.stripe.android.PaymentConfiguration.init(this.publishableKey);
+    this._paymentConfigurationInitiated = true;
   }
 
   static shared(): StripeConfig {

--- a/src/standard/standard.ios.ts
+++ b/src/standard/standard.ios.ts
@@ -2,19 +2,13 @@ import { Page } from "tns-core-modules/ui/page";
 import { StripeAddress, StripeConfigCommon, StripePaymentListener, StripePaymentMethod, StripeShippingAddressField, StripeShippingMethod } from "./standard.common";
 
 export class StripeConfig extends StripeConfigCommon {
-  private _native: STPPaymentConfiguration;
   get native(): STPPaymentConfiguration {
     // getter gives client a chance to set properties before using.
-    if (!this._native) this._native = this.toNative();
-    return this._native;
-  }
-
-  private toNative(): STPPaymentConfiguration {
     if (!this.publishableKey) throw new Error("publishableKey must be set");
     let config = STPPaymentConfiguration.sharedConfiguration();
-    if (this.publishableKey) config.publishableKey = this.publishableKey;
-    if (this.appleMerchantID) config.appleMerchantIdentifier = this.appleMerchantID;
-    if (this.requiredBillingAddressFields) config.requiredBillingAddressFields = this.requiredBillingAddressFields as any;
+    config.publishableKey = this.publishableKey;
+    config.appleMerchantIdentifier = this.appleMerchantID;
+    config.requiredBillingAddressFields = this.requiredBillingAddressFields as any;
     if (this.requiredShippingAddressFields && this.requiredShippingAddressFields.length > 0) {
       let fields = new NSMutableSet<string>({capacity: 4});
       this.requiredShippingAddressFields.forEach(f => {
@@ -34,8 +28,10 @@ export class StripeConfig extends StripeConfigCommon {
         }
       });
       config.requiredShippingAddressFields = fields;
+    } else {
+      config.requiredShippingAddressFields = undefined;
     }
-    if (this.companyName) config.companyName = this.companyName;
+    config.companyName = this.companyName;
     return config;
   }
 


### PR DESCRIPTION
## What is the current behavior?
When creating a new `StripePaymentSession`, changes since previous creation are ignored.

## What is the new behavior?
`StripeConfig` is re-read when creating `StripePaymentSession`.

Fixes/Implements/Closes #101 .
