### PR TITLE
fix(prefilled-address): PaymentSession with prefilledAddress crashes on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 
+## 6.3.2 (2020, April 4)
+### Fixes
+- [(# 103)](https://github.com/triniwiz/nativescript-stripe/issues/103) Android PaymentSession with Prefilled Address crashes
+
 ## 6.3.1 (2020, April 1)
 ### Fixes
 - [(# 101)](https://github.com/triniwiz/nativescript-stripe/issues/101) PaymentSession Doesn't Reread Config. Re-reads StripeConfig when a new PaymentSession is created.

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-stripe",
-  "version": "6.3.1",
+  "version": "6.3.2",
   "description": "NativeScript Stripe sdk",
   "main": "stripe",
   "typings": "index.d.ts",


### PR DESCRIPTION
## What is the current behavior?
Using a prefilled address with `StripePaymentSession` on Android crashes.

Fixes #103 .
