### PR TITLE
Enable postal code input on Angular Intent demo on Android

### DIFF
--- a/demo-angular/app/demo/intent.component.ts
+++ b/demo-angular/app/demo/intent.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, ViewContainerRef } from "@angular/core";
+import { ChangeDetectorRef, Component, ViewContainerRef, ViewChild, ElementRef, AfterViewInit } from "@angular/core";
 import { ModalDialogService } from "nativescript-angular/modal-dialog";
 import { Card, CreditCardView, PaymentMethod, Stripe, StripePaymentIntentParams } from "nativescript-stripe";
 import { alert } from "tns-core-modules/ui/dialogs";
@@ -10,7 +10,9 @@ import { publishableKey, StripeService } from "./stripe.service";
   moduleId: module.id,
   templateUrl: "./intent.component.html",
 })
-export class IntentComponent {
+export class IntentComponent implements AfterViewInit {
+  @ViewChild('card', { static: false }) cardViewElement: ElementRef;
+  cardView: CreditCardView;
   payment: string;
   status: string;
   private stripe: Stripe;
@@ -30,6 +32,16 @@ export class IntentComponent {
       throw new Error("publishableKey must be changed from placeholder");
     }
     this.stripe = new Stripe(publishableKey);
+  }
+
+  ngAfterViewInit() {
+    this.cardView = <CreditCardView>this.cardViewElement.nativeElement;
+
+    // Enable Postal Code input on Android after a slight delay
+    const that = this;
+    setTimeout(function() {
+      that.cardView.android.setPostalCodeEnabled(true);
+    }, 500);
   }
 
   openModal() {

--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation 'com.stripe:stripe-android:12.0.1'
+    implementation 'com.stripe:stripe-android:12.7.0'
 }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When navigating to the Angular Intent Demo on an Android 10.0 virtual device, the CreditCardView does not contain a postal code field.

## What is the new behavior?
<!-- Describe the changes. -->
Upgraded the Stripe SDK version to 12.7.0 in order to set the postal code to be enabled in the CreditCardView on the intent component.

Fixes/Implements/Closes #114 .

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

